### PR TITLE
Add 4 F compsets with wiso to CIME

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -8,7 +8,7 @@
       CAM
     ===============
    -->
-    <desc atm="CAM60[%1PCT][%4xCO2][%CCTS][%CFIRE][%CVBSX][%PORT][%RCO2][%SCAM][%SDYN][%WCCM][%WCMD][%WCSC][%WCTS][%WXIE]">CAM cam6 physics:</desc>
+    <desc atm="CAM60[%1PCT][%4xCO2][%CCTS][%CFIRE][%CVBSX][%PORT][%RCO2][%SCAM][%SDYN][%WCCM][%WCMD][%WCSC][%WCTS][%WXIE][%WISO]">CAM cam6 physics:</desc>
     <desc atm="CAM50[%CCTS][%CLB][%PORT][%RCO2][%SCAM][%SDYN][%WCSC][%WCTS]"              >CAM cam5 physics:</desc>
     <desc atm="CAM40[%PORT][%RCO2][%SCAM][%SDYN][%TMOZ][%WXIE][%WXIED][%WCMD]"                   >CAM cam4 physics:</desc>
     <desc atm="CAM[%ADIAB][%DABIP04][%TJ16][%HS94][%KESSLER][%RCO2][%SPCAMS][%SPCAMCLBS][%SPCAMM][%SPCAMCLBM]">CAM simplified and non-versioned physics :</desc>
@@ -43,6 +43,14 @@
     <desc option="SPCAMM"       >CAM super-parameterized CAM double moment m2005 SAM microphysics </desc>
     <desc option="SPCAMCLBM"    >CAM super-parameterized CAM double moment m2005 SAM microphysics using CLUBB </desc>
     <desc option="TMOZ"         >CAM tropospheric chemistry with bulk aerosols:</desc>
+
+  <!--
+    ===================
+    CAM - Water Tracers
+    ===================
+  -->
+
+    <desc option="WISO"         >CAM with water isotopes/tracers.</desc>
 
   <!--
     ===============
@@ -127,6 +135,9 @@
       <value compset="_CAM40%TMOZ">-chem trop_mozart</value>
 
       <value compset="_CAM.*_BGC%B">-co2_cycle</value>
+
+      <!-- Modifiers for CAM with water isotopes -->
+      <value compset="_CAM60%WISO">-water_tracer h2o_h216o_hdo_h218o</value>
 
       <!-- Match against "%WC" to set defaults for all WACCM cases. -->
       <!-- Later settings of "-chem" take precedence over earlier ones. -->

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -142,6 +142,28 @@
     <lname>HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
   </compset>
 
+  <!-- CAM water isotope compsets -->
+
+  <compset>
+    <alias>FiHIST</alias>
+    <lname>HIST_CAM60%WISO_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>Fi2010climo</alias>
+    <lname>2010_CAM60%WISO_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>Fi2010climo</alias>
+    <lname>2000_CAM60%WISO_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>Fi1850climo</alias>
+    <lname>1850_CAM60%WISO_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+  </compset>
+
   <!-- CAM simpler model compsets -->
 
   <compset>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -155,7 +155,7 @@
   </compset>
 
   <compset>
-    <alias>Fi2010climo</alias>
+    <alias>Fi2000climo</alias>
     <lname>2000_CAM60%WISO_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
   </compset>
 


### PR DESCRIPTION
Adds %WISO option to CAM6 in CIME xml definitions (including required change to CAM_CONFIG_OPTS), and defines 4 F compsets with water isotopes: a) FiHIST, based on FHIST, b) Fi2010climo, based on F2010climo, c) Fi2000climo, based on F2000climo, and d) Fi1850climo, based on F1850climo.