### PR TITLE
Fix wtrc_precip_evap mass fixer routine.

### DIFF
--- a/src/physics/cam/water_tracers.F90
+++ b/src/physics/cam/water_tracers.F90
@@ -5340,9 +5340,9 @@ integer :: ncol               !Number of atmospheric columns
 integer :: i,k,m              !loop variables
 
 !For precip mass fixer:
-real(r8) :: rdiff 
+real(r8) :: pdiff 
 real(r8) :: sdiff 
-real(r8) :: rmass0
+real(r8) :: pmass0
 real(r8) :: smass0
 real(r8) :: Rd
 
@@ -5633,17 +5633,17 @@ end do
 !-----------------------
 do i=1,ncol
  !Calculate differences:
-  rmass0 = (prec(i,wtrc_iatype(2,iwtvap))-snow(i,wtrc_iatype(2,iwtvap)))
+  pmass0 = prec(i,wtrc_iatype(2,iwtvap))
   smass0 = snow(i,wtrc_iatype(2,iwtvap))
-  rdiff  = rmass0 - (prec(i,wtrc_iatype(1,iwtvap))-snow(i,wtrc_iatype(1,iwtvap)))
-  sdiff  = smass0-snow(i,wtrc_iatype(1,iwtvap))
+  pdiff  = pmass0 - prec(i,wtrc_iatype(1,iwtvap))
+  sdiff  = smass0 - snow(i,wtrc_iatype(1,iwtvap))
   do m=2,wtrc_nwset
-   !Rain errors:
-    Rd = wtrc_ratio(iwspec(wtrc_iatype(m,iwtvap)),(prec(i,wtrc_iatype(m,iwtvap))-snow(i,wtrc_iatype(m,iwtvap))),rmass0)
-    prec(i,wtrc_iatype(m,iwtvap)) = prec(i,wtrc_iatype(m,iwtvap))-Rd*rdiff    
+   !Total precip errors:
+    Rd = wtrc_ratio(iwspec(wtrc_iatype(m,iwtvap)),prec(i,wtrc_iatype(m,iwtvap)),pmass0)
+    prec(i,wtrc_iatype(m,iwtvap)) = max(0._r8,prec(i,wtrc_iatype(m,iwtvap))-Rd*pdiff)    
    !Snow errors:
     Rd = wtrc_ratio(iwspec(wtrc_iatype(m,iwtvap)),snow(i,wtrc_iatype(m,iwtvap)),smass0)
-    snow(i,wtrc_iatype(m,iwtvap)) = snow(i,wtrc_iatype(m,iwtvap))-Rd*sdiff           
+    snow(i,wtrc_iatype(m,iwtvap)) = max(0._r8,snow(i,wtrc_iatype(m,iwtvap))-Rd*sdiff)           
    !Giant error check: 
    !NOTE:  !Seems to occur baout once every seven years. -JN
     if(prec(i,wtrc_iatype(m,iwtvap)) .gt. 10._r8*prec(i,wtrc_iatype(1,iwtvap))) then


### PR DESCRIPTION
Fixes a bug where the mass fixer at the end of wtrc_precip_evap
can cause negative precipitation rates. Previous version had
corrected the total precip mass based on the rain mass only
instead of rain + snow.