### PR TITLE
[wip] update Externals_CAM.cfg 

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -47,9 +47,9 @@ local_path = components/rtm
 required = True
 
 [ww3]
-tag = trunk_tags/ww3_190402
-protocol = svn
-repo_url =  https://svn-ccsm-models.cgd.ucar.edu/ww3
+tag = ww3_190402
+protocol = git
+repo_url =  https://github.com/ESCOMP/WW3-CESM.git
 local_path = components/ww3
 required = True
 

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -1,29 +1,29 @@
 [chem_proc]
 local_path = chem_proc
 protocol = git
-repo_url = https://github.com/ESCOMP/CHEM_PREPROCESSOR.git
+repo_url = https://github.com/ESCOMP/CHEM_PREPROCESSOR
 tag = chem_proc5_0_03
 required = True
 
 [carma]
 local_path = src/physics/carma/base
-protocol = git 
-repo_url = https://github.com/ESCOMP/CARMA_base.git
+protocol = git
+repo_url = https://github.com/ESCOMP/CARMA_base
 tag = carma3_49
 required = True
 
 [clubb]
 local_path = src/physics/clubb
-protocol = svn
-repo_url = https://svn-ccsm-models.cgd.ucar.edu/clubb_core/branch_tags/
-tag = vendor_clubb_r8099_geotrace3_tags/vendor_clubb_r8099_geotrace3_n02
+protocol = git
+repo_url = https://github.com/rfiorella/CLUBB_CESM
+tag = vendor_clubb_r8099_geotrace3_n02
 required = True
 
 [cosp2]
 local_path = src/physics/cosp2/src
-protocol = svn
-repo_url = https://github.com/CFMIP/COSPv2.0/tags/
-tag = v2.0.3cesm/src
+protocol = git
+repo_url = https://github.com/CFMIP/COSPv2.0/
+tag = v2.0.3cesm
 required = True
 
 [externals_description]

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -1,14 +1,14 @@
 [chem_proc]
 local_path = chem_proc
-protocol = svn
-repo_url = https://svn-ccsm-models.cgd.ucar.edu/tools/proc_atm/chem_proc/trunk_tags/
+protocol = git
+repo_url = https://github.com/ESCOMP/CHEM_PREPROCESSOR.git
 tag = chem_proc5_0_03
 required = True
 
 [carma]
 local_path = src/physics/carma/base
-protocol = svn
-repo_url = https://svn-ccsm-models.cgd.ucar.edu/carma/trunk_tags/
+protocol = git 
+repo_url = https://github.com/ESCOMP/CARMA_base.git
 tag = carma3_49
 required = True
 


### PR DESCRIPTION
Updates Externals_CAM.cfg to use github versions of repos.
A few additional notes:
1. Requires checking out a new version of manage_externals:
https://bb.cgd.ucar.edu/cesm/threads/known-issue-running-manage_externals-with-python-3-8-and-later.5072/
(Can add the new version to a new commit here before PR is merged
if needed, but could also setup a new submodule).
2. Will need to update CIME hash after derecho updates have been
merged in nusbaume/cime